### PR TITLE
expose user path

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ apps:
       JAVA_HOME: "$SNAP/java-se-7u75-ri"
       HADOOP_HOME: "$SNAP/hadoop-2.7.2"
       CLASSPATH: "$($HADOOP_HOME/bin/hdfs classpath --glob)"
-      PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$SNAP/usr/bin:$SNAP/bin:$HADOOP_HOME/sbin:$HADOOP_HOME/bin"
+      PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$SNAP/usr/bin:$SNAP/bin:$HADOOP_HOME/sbin:$HADOOP_HOME/bin:$PATH"
 parts:
   dvc-libs:
     plugin: nil


### PR DESCRIPTION
Fixes #112.

This is the same fix as #42 which seems to have been lost [two commits later](https://github.com/iterative/dvc-snap/blob/2e649bb679961b87e917a2d7dfd7015113232b20/snap/snapcraft.yaml#L23).