### PR TITLE
snap: use python 3.10

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: Build package
 on: [push, pull_request]
 jobs:
   snap:
-    runs-on: ubuntu-20.04  # https://github.com/snapcore/action-build/issues/42
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: snapcore/action-build@v1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,12 +22,13 @@ apps:
       CLASSPATH: "$($HADOOP_HOME/bin/hdfs classpath --glob)"
       PATH: "/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$SNAP/usr/bin:$SNAP/bin:$HADOOP_HOME/sbin:$HADOOP_HOME/bin:$PATH"
 parts:
-  dvc-libs:
-    plugin: nil
+  dvc:
+    plugin: python
+    source: https://github.com/iterative/dvc.git
+    source-tag: 3.44.0
     build-packages:
-    - curl
-    - tar
-    - gzip
+    - git
+    - libc-dev
     stage-packages:
     - git
     - libpython3-stdlib
@@ -41,28 +42,13 @@ parts:
     - python3-distutils
     - python3-pkg-resources
     - python3.10-minimal
-    override-build: |
-        craftctl default
-        curl -sSLO https://s3-us-east-2.amazonaws.com/dvc-public/dvc-test/openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz
-        curl -sSLO https://s3-us-east-2.amazonaws.com/dvc-public/dvc-test/hadoop-2.7.2.tar.gz
-        tar -xzf openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz -C $CRAFT_PART_INSTALL
-        tar -xzf hadoop-2.7.2.tar.gz -C $CRAFT_PART_INSTALL
-  dvc:
-    after: [dvc-libs]
-    plugin: python
-    source: https://github.com/iterative/dvc.git
-    source-tag: 3.44.0
-    build-packages:
-    - git
-    - libc-dev
     override-pull: |
         craftctl default
         git diff --quiet || error_dirty_build
-        $SNAP/usr/bin/python3 --version
         echo 'PKG = "snap"' > dvc/_build.py
     override-build: |
         craftctl default
-        $CRAFT_PART_INSTALL/bin/python3 -m pip install -U .[all]
-        $CRAFT_PART_INSTALL/bin/python3 -m dvc --version
-        find "${CRAFT_PART_INSTALL}" -type f -executable -print0 | xargs -0 sed -i "1 s|^#\\!${CRAFT_PART_INSTALL}/bin/python3.*$|#\\!/usr/bin/env python3|"
-        $CRAFT_PART_INSTALL/bin/python3 -m dvc completion -s bash > $CRAFT_PART_INSTALL/completion.sh
+        $PARTS_PYTHON_INTERPRETER -m pip install -U pip setuptools_scm build
+        $PARTS_PYTHON_INTERPRETER -m pip install -U .[all]
+        $PARTS_PYTHON_INTERPRETER -m dvc --version
+        $PARTS_PYTHON_INTERPRETER -m dvc completion -s bash > $CRAFT_PART_INSTALL/completion.sh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ description: Git for Data & Models https://dvc.org
 version: 3.44.0
 confinement: classic
 grade: stable
-base: core20
+base: core22
 license: Apache-2.0
 layout:
   /etc/dvc:
@@ -31,8 +31,8 @@ parts:
     stage-packages:
     - git
     - libpython3-stdlib
-    - libpython3.9-stdlib
-    - libpython3.9-minimal
+    - libpython3.10-stdlib
+    - libpython3.10-minimal
     - python3-pip
     - python3-setuptools
     - python3-wheel
@@ -40,7 +40,7 @@ parts:
     - python3-minimal
     - python3-distutils
     - python3-pkg-resources
-    - python3.9-minimal
+    - python3.10-minimal
     override-build: |
         snapcraftctl build
         curl -sSLO https://s3-us-east-2.amazonaws.com/dvc-public/dvc-test/openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,8 +31,8 @@ parts:
     stage-packages:
     - git
     - libpython3-stdlib
-    - libpython3.8-stdlib
-    - libpython3.8-minimal
+    - libpython3.9-stdlib
+    - libpython3.9-minimal
     - python3-pip
     - python3-setuptools
     - python3-wheel
@@ -40,7 +40,7 @@ parts:
     - python3-minimal
     - python3-distutils
     - python3-pkg-resources
-    - python3.8-minimal
+    - python3.9-minimal
     override-build: |
         snapcraftctl build
         curl -sSLO https://s3-us-east-2.amazonaws.com/dvc-public/dvc-test/openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz
@@ -67,4 +67,4 @@ parts:
         find "${SNAPCRAFT_PART_INSTALL}" -type f -executable -print0 | xargs -0 sed -i "1 s|^#\\!${SNAPCRAFT_PART_INSTALL}/bin/python3.*$|#\\!/usr/bin/env python3|"
         $SNAPCRAFT_PART_INSTALL/bin/python3 -m dvc completion -s bash > $SNAPCRAFT_PART_INSTALL/completion.sh
         # python3 fixup symlink (snapcraft bug)
-        ln -sf ../usr/bin/python3.8 $SNAPCRAFT_PART_INSTALL/bin/python3
+        ln -sf ../usr/bin/python3.9 $SNAPCRAFT_PART_INSTALL/bin/python3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
     - python3-pkg-resources
     - python3.10-minimal
     override-build: |
-        craftctl build
+        craftctl default
         curl -sSLO https://s3-us-east-2.amazonaws.com/dvc-public/dvc-test/openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz
         curl -sSLO https://s3-us-east-2.amazonaws.com/dvc-public/dvc-test/hadoop-2.7.2.tar.gz
         tar -xzf openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz -C $CRAFT_PART_INSTALL

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,8 +45,8 @@ parts:
         craftctl build
         curl -sSLO https://s3-us-east-2.amazonaws.com/dvc-public/dvc-test/openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz
         curl -sSLO https://s3-us-east-2.amazonaws.com/dvc-public/dvc-test/hadoop-2.7.2.tar.gz
-        tar -xzf openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz -C $SNAPCRAFT_PART_INSTALL
-        tar -xzf hadoop-2.7.2.tar.gz -C $SNAPCRAFT_PART_INSTALL
+        tar -xzf openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz -C $CRAFT_PART_INSTALL
+        tar -xzf hadoop-2.7.2.tar.gz -C $CRAFT_PART_INSTALL
   dvc:
     after: [dvc-libs]
     plugin: python
@@ -62,9 +62,9 @@ parts:
         echo 'PKG = "snap"' > dvc/_build.py
     override-build: |
         craftctl build
-        $SNAPCRAFT_PART_INSTALL/bin/python3 -m pip install -U .[all]
-        $SNAPCRAFT_PART_INSTALL/bin/python3 -m dvc --version
-        find "${SNAPCRAFT_PART_INSTALL}" -type f -executable -print0 | xargs -0 sed -i "1 s|^#\\!${SNAPCRAFT_PART_INSTALL}/bin/python3.*$|#\\!/usr/bin/env python3|"
-        $SNAPCRAFT_PART_INSTALL/bin/python3 -m dvc completion -s bash > $SNAPCRAFT_PART_INSTALL/completion.sh
+        $CRAFT_PART_INSTALL/bin/python3 -m pip install -U .[all]
+        $CRAFT_PART_INSTALL/bin/python3 -m dvc --version
+        find "${CRAFT_PART_INSTALL}" -type f -executable -print0 | xargs -0 sed -i "1 s|^#\\!${CRAFT_PART_INSTALL}/bin/python3.*$|#\\!/usr/bin/env python3|"
+        $CRAFT_PART_INSTALL/bin/python3 -m dvc completion -s bash > $CRAFT_PART_INSTALL/completion.sh
         # python3 fixup symlink (snapcraft bug)
-        ln -sf ../usr/bin/python3.9 $SNAPCRAFT_PART_INSTALL/bin/python3
+        ln -sf ../usr/bin/python3.9 $CRAFT_PART_INSTALL/bin/python3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,5 +66,3 @@ parts:
         $CRAFT_PART_INSTALL/bin/python3 -m dvc --version
         find "${CRAFT_PART_INSTALL}" -type f -executable -print0 | xargs -0 sed -i "1 s|^#\\!${CRAFT_PART_INSTALL}/bin/python3.*$|#\\!/usr/bin/env python3|"
         $CRAFT_PART_INSTALL/bin/python3 -m dvc completion -s bash > $CRAFT_PART_INSTALL/completion.sh
-        # python3 fixup symlink (snapcraft bug)
-        ln -sf ../usr/bin/python3.9 $CRAFT_PART_INSTALL/bin/python3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
     - python3-pkg-resources
     - python3.10-minimal
     override-build: |
-        snapcraftctl build
+        craftctl build
         curl -sSLO https://s3-us-east-2.amazonaws.com/dvc-public/dvc-test/openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz
         curl -sSLO https://s3-us-east-2.amazonaws.com/dvc-public/dvc-test/hadoop-2.7.2.tar.gz
         tar -xzf openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz -C $SNAPCRAFT_PART_INSTALL
@@ -56,12 +56,12 @@ parts:
     - git
     - libc-dev
     override-pull: |
-        snapcraftctl pull
+        craftctl pull
         git diff --quiet || error_dirty_build
         $SNAP/usr/bin/python3 --version
         echo 'PKG = "snap"' > dvc/_build.py
     override-build: |
-        snapcraftctl build
+        craftctl build
         $SNAPCRAFT_PART_INSTALL/bin/python3 -m pip install -U .[all]
         $SNAPCRAFT_PART_INSTALL/bin/python3 -m dvc --version
         find "${SNAPCRAFT_PART_INSTALL}" -type f -executable -print0 | xargs -0 sed -i "1 s|^#\\!${SNAPCRAFT_PART_INSTALL}/bin/python3.*$|#\\!/usr/bin/env python3|"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,12 +56,12 @@ parts:
     - git
     - libc-dev
     override-pull: |
-        craftctl pull
+        craftctl default
         git diff --quiet || error_dirty_build
         $SNAP/usr/bin/python3 --version
         echo 'PKG = "snap"' > dvc/_build.py
     override-build: |
-        craftctl build
+        craftctl default
         $CRAFT_PART_INSTALL/bin/python3 -m pip install -U .[all]
         $CRAFT_PART_INSTALL/bin/python3 -m dvc --version
         find "${CRAFT_PART_INSTALL}" -type f -executable -print0 | xargs -0 sed -i "1 s|^#\\!${CRAFT_PART_INSTALL}/bin/python3.*$|#\\!/usr/bin/env python3|"


### PR DESCRIPTION
We no longer support 3.8 that core20 is using, so migrating to a newer version.